### PR TITLE
Use golang 1.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.6
+FROM golang:1.7
 RUN go get -u -v github.com/derekparker/delve/cmd/dlv
 EXPOSE 2345
 


### PR DESCRIPTION
The current version of delve now requires golang 1.7 or higher.